### PR TITLE
Use QtCoreApplication as well as QtApplication

### DIFF
--- a/qt4reactor.py
+++ b/qt4reactor.py
@@ -135,7 +135,7 @@ class QtReactor(posixbase.PosixReactorBase):
         self._timer.setSingleShot(True)
         QObject.connect(self._timer, SIGNAL("timeout()"), self.iterate)
 
-        if QCoreApplication.startingUp():
+        if QCoreApplication.instance() is None:
             # Application Object has not been started yet
             self.qApp=QCoreApplication([])
             self._ownApp=True


### PR DESCRIPTION
Changed test for existing QtCoreApplication to workaround apparent bug when a QtCoreApplication has been created rather than a QtApplication.

Previously:
```from   PySide.QtCore import *
from   qtreactor     import qt4reactor
app = QCoreApplication([])
qt4reactor.install()

``````
would result in ```RuntimeError: A QCoreApplication instance already exists.```
``````
