### PR TITLE
Merge request: add setup.py to the project

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+#
+# See LICENSE file for copyright and license details.
+
+"""Setup.py: build, distribute, clean."""
+
+import os
+import sys
+
+from distutils import log
+from distutils.core import setup
+from glob import glob
+
+
+setup(
+    name='qt4reactor',
+    version='1.0',
+    license='MIT',
+    author='Glenn H. Tarbox',
+    author_email='glenn@tarbox.org',
+    description='Twisted Qt4 Integration',
+    long_description='Provides support for Twisted to be driven by the ' \
+                     'Qt mainloop.',
+    url='https://github.com/ghtdak/qtreactor',
+    scripts=glob("./bin/*"),
+    py_modules=['qt4reactor', 'gtrial'],
+)


### PR DESCRIPTION
Hello!

I'm a developer of the Ubuntu One project (https://launchpad.net/ubuntuone), where we heavily use the qt4reactor for a couple of QT UIs we provide (see for example https://launchpad.net/ubuntuone-control-panel).

I'm building ubuntu packages for our QT UI's, and since we depend on qt4reactor, we need to also package it for Ubuntu in particular. So, I'm proposing a branch where the distutils' setup.py is added to this project and thus tarballs can be created from the source tree using:

./setup.py sdist

With this setup.py, you can also install the qt4reactor module and the binary gtrial, using something like:

./setup.py install --prefix=/tmp/qtreactor

or if you want to install directly to the system's python lib:

sudo ./setup.py install

This setup.py will also allow creating tarballs to upload to sites such as pypi, and will also allow me to create the .deb package (I will be creating a separated packaging branch to accomplish this).

Let me know if the information I added for version, author and author_email is correct, I kind of guessed that from the site. I'm happy to make any change you consider necessary.

Thank you very much!
Regards, Natalia.
