### PR TITLE
Make code pep8 compliant

### DIFF
--- a/gtrial.py
+++ b/gtrial.py
@@ -2,40 +2,40 @@ import sys
 from PyQt4 import QtGui, QtScript
 from PyQt4.QtCore import QTimer, SIGNAL, QEventLoop
 import qt4reactor
-        
+
 app = QtGui.QApplication(sys.argv)
 
 qt4reactor.install()
 
 from twisted.internet import reactor, task
 
+
 class doNothing(object):
     def __init__(self):
         self.count = 0
-        self.running=False
-        
+        self.running = False
+
     def buttonClick(self):
         if not self.running:
             from twisted.scripts import trial
             trial.run()
-            
+
+
 def run():
 
-    t=doNothing()
-    
+    t = doNothing()
+
     engine = QtScript.QScriptEngine()
-    
+
     button = QtGui.QPushButton()
     scriptButton = engine.newQObject(button)
     engine.globalObject().setProperty("button", scriptButton)
-    
+
     app.connect(button, SIGNAL("clicked()"), t.buttonClick)
-    
+
     engine.evaluate("button.text = 'Do Twisted Gui Trial'")
     engine.evaluate("button.styleSheet = 'font-style: italic'")
     engine.evaluate("button.show()")
-    
+
     app.exec_()
     print 'fell off the bottom?...'
-
-

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 from distutils.core import setup
 from glob import glob
 
-classifiers=[
+classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Environment :: X11 Applications :: Qt',
     'Framework :: Twisted',

--- a/twisted/plugins/qt4.py
+++ b/twisted/plugins/qt4.py
@@ -6,4 +6,3 @@ from twisted.application.reactors import Reactor
 
 qt4 = Reactor('qt4', 'qt4reactor', 'Qt4 integration reactor')
 qt4bad = Reactor('qt4bad', 'qt4reactor_bad', 'Qt4 broken reactor')
-


### PR DESCRIPTION
In this pull request, the code (excluding the tests) is made [pep8](http://www.python.org/dev/peps/pep-0008/) compliant.
I've used the tool [pep8 - Python style guide checker](https://github.com/jcrocholl/pep8).
You can install it with the command `pip install pep8`.

Existing code:

```
shell> pep8 . --exclude=ghtTests/
./gtrial.py:5:1: W293 blank line contains whitespace
./gtrial.py:12:1: E302 expected 2 blank lines, found 1
./gtrial.py:15:21: E225 missing whitespace around operator
./gtrial.py:16:1: W293 blank line contains whitespace
./gtrial.py:21:1: W293 blank line contains whitespace
./gtrial.py:22:1: E302 expected 2 blank lines, found 1
./gtrial.py:24:6: E225 missing whitespace around operator
./gtrial.py:25:1: W293 blank line contains whitespace
./gtrial.py:27:1: W293 blank line contains whitespace
./gtrial.py:31:1: W293 blank line contains whitespace
./gtrial.py:33:1: W293 blank line contains whitespace
./gtrial.py:37:1: W293 blank line contains whitespace
./gtrial.py:41:1: W391 blank line at end of file
./qt4reactor.py:12:1: W293 blank line contains whitespace
./qt4reactor.py:48:80: E501 line too long (87 > 79 characters)
./qt4reactor.py:51:80: E501 line too long (88 > 79 characters)
./qt4reactor.py:74:5: E303 too many blank lines (2)
./qt4reactor.py:82:5: E303 too many blank lines (2)
./qt4reactor.py:86:80: E501 line too long (89 > 79 characters)
./qt4reactor.py:87:9: E301 expected 1 blank line, found 0
./qt4reactor.py:101:47: E261 at least two spaces before inline comment
./qt4reactor.py:101:80: E501 line too long (97 > 79 characters)
./qt4reactor.py:109:9: E301 expected 1 blank line, found 0
./qt4reactor.py:112:1: W293 blank line contains whitespace
./qt4reactor.py:127:1: E303 too many blank lines (3)
./qt4reactor.py:140:22: E225 missing whitespace around operator
./qt4reactor.py:141:25: E225 missing whitespace around operator
./qt4reactor.py:144:25: E225 missing whitespace around operator
./qt4reactor.py:149:5: E303 too many blank lines (2)
./qt4reactor.py:160:5: E303 too many blank lines (2)
./qt4reactor.py:167:5: E303 too many blank lines (2)
./qt4reactor.py:174:5: E303 too many blank lines (2)
./qt4reactor.py:185:1: W293 blank line contains whitespace
./qt4reactor.py:186:5: E303 too many blank lines (2)
./qt4reactor.py:193:5: E303 too many blank lines (2)
./qt4reactor.py:200:5: E303 too many blank lines (2)
./qt4reactor.py:208:5: E303 too many blank lines (2)
./qt4reactor.py:212:5: E303 too many blank lines (2)
./qt4reactor.py:216:5: E303 too many blank lines (2)
./qt4reactor.py:216:23: E231 missing whitespace after ','
./qt4reactor.py:217:31: E231 missing whitespace after ','
./qt4reactor.py:222:5: E303 too many blank lines (2)
./qt4reactor.py:226:1: W293 blank line contains whitespace
./qt4reactor.py:228:5: E303 too many blank lines (2)
./qt4reactor.py:237:80: E501 line too long (89 > 79 characters)
./qt4reactor.py:238:1: W293 blank line contains whitespace
./qt4reactor.py:255:5: E303 too many blank lines (2)
./qt4reactor.py:260:5: E303 too many blank lines (2)
./qt4reactor.py:274:1: W293 blank line contains whitespace
./qt4reactor.py:275:5: E303 too many blank lines (2)
./qt4reactor.py:282:5: E303 too many blank lines (2)
./qt4reactor.py:290:5: E303 too many blank lines (2)
./qt4reactor.py:295:80: E501 line too long (90 > 79 characters)
./qt4reactor.py:308:5: E303 too many blank lines (2)
./qt4reactor.py:318:1: W293 blank line contains whitespace
./qt4reactor.py:319:5: E303 too many blank lines (2)
./qt4reactor.py:324:5: E303 too many blank lines (2)
./qt4reactor.py:352:80: E501 line too long (81 > 79 characters)
./qt4reactor.py:359:1: W391 blank line at end of file
./setup.py:10:12: E225 missing whitespace around operator
./twisted/plugins/qt4.py:9:1: W391 blank line at end of file
```

In this branch:

```
shell> pep8 . --exclude=ghtTests/
shell>
```
