### PR TITLE
fix imports after reorganization to package

### DIFF
--- a/bin/gtrial
+++ b/bin/gtrial
@@ -22,6 +22,6 @@ if hasattr(os, "getuid") and os.getuid() != 0:
 sys.path[:] = map(os.path.abspath, sys.path)
 # end chdir armor
 
-from gtrial import run
+from qtreactor.gtrial import run
 
 run()

--- a/ghtTests/fakeAppButtonStress.py
+++ b/ghtTests/fakeAppButtonStress.py
@@ -7,9 +7,9 @@ from PyQt4 import QtCore
 
 app = QtGui.QApplication(sys.argv)
 
-import qt4reactor
+from qtreactor import pyqt4reactor
 
-qt4reactor.install()
+pyqt4reactor.install()
 
 from twisted.internet import reactor, task
 

--- a/ghtTests/ircClient.py
+++ b/ghtTests/ircClient.py
@@ -1,11 +1,11 @@
 from __future__ import print_function
 
-import qt4reactor
+from qtreactor import pyqt4reactor
 
 from PyQt4 import QtGui
 
 app = QtGui.QApplication(sys.argv)
-qt4reactor.install()
+pyqt4reactor.install()
 
 from twisted.words.protocols import irc
 from twisted.internet import reactor, protocol

--- a/ghtTests/testIterate.py
+++ b/ghtTests/testIterate.py
@@ -7,9 +7,9 @@ from PySide.QtCore import SIGNAL
 
 app = QtGui.QApplication(sys.argv)
 
-import qt4reactor
+from qtreactor import pyqt4reactor
 
-qt4reactor.install()
+pyqt4reactor.install()
 
 from twisted.internet import reactor, task
 from twisted.python import log

--- a/qtreactor/gtrial.py
+++ b/qtreactor/gtrial.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import sys
 
@@ -8,7 +8,7 @@ from PyQt4.QtCore import SIGNAL
 
 app = QtGui.QApplication(sys.argv)
 
-import pyqt4reactor
+from qtreactor import pyqt4reactor
 
 pyqt4reactor.install()
 

--- a/qtreactor/pyqt4reactor.py
+++ b/qtreactor/pyqt4reactor.py
@@ -11,15 +11,15 @@ Maintainer: U{Glenn H Tarbox, PhD<mailto:glenn@tarbox.org>}
 
 """
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 from twisted.python import runtime
 
-import qtreactor_config
+from qtreactor import qtreactor_config
 
 qtreactor_config.set_qt_name("PyQt4")
 
-import qt4base
+from qtreactor import qt4base
 
 class pyqt4reactor(qt4base.QtReactor):
     pass

--- a/qtreactor/pyside4reactor.py
+++ b/qtreactor/pyside4reactor.py
@@ -11,15 +11,15 @@ Maintainer: U{Glenn H Tarbox, PhD<mailto:glenn@tarbox.org>}
 
 """
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 from twisted.python import runtime
 
-import qtreactor_config
+from qtreactor import qtreactor_config
 
 qtreactor_config.set_qt_name("PySide")
 
-import qt4base
+from qtreactor import qt4base
 
 class pyqt4reactor(qt4base.QtReactor):
     pass

--- a/qtreactor/qt4base.py
+++ b/qtreactor/qt4base.py
@@ -11,7 +11,7 @@ Maintainer: U{Glenn H Tarbox, PhD<mailto:glenn@tarbox.org>}
 
 """
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 import sys
 
 from zope.interface import implements
@@ -19,7 +19,7 @@ from twisted.internet.interfaces import IReactorFDSet
 from twisted.python import log, runtime
 from twisted.internet import posixbase
 
-import qtreactor_config
+from qtreactor import qtreactor_config
 
 if qtreactor_config.get_qt_name() == "PyQt4":
     from PyQt4 import QtCore


### PR DESCRIPTION
I think that after reorganization to package it makes sense to make imports absolute - all submodules are no longer available directly, they are under `qtreactor` namespace. Imports at ghtTests and bin/gtrial didn't work; imports in modules located in `qtreactor` worked only because they were resolved as relative to a current dir. To avoid such errors I've added `absolute_imports` future import to `qtreactor.*` modules.
